### PR TITLE
Add Makefile to streamline Docker and Docker Compose workflows

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,8 @@
 # syntax = docker/dockerfile:1.4
+<<<<<<< Updated upstream
+=======
+# Dockerfile
+>>>>>>> Stashed changes
 
 FROM tiangolo/uvicorn-gunicorn-fastapi:python3.9-slim AS builder
 

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,42 @@
+# Makefile
+
+# Variables
+IMAGE_NAME     := healthgen-api
+CONTAINER_NAME := healthgen-conversation-fsm
+COMPOSE_FILE   := compose.yaml
+PORT           := 8000
+
+.PHONY: help build docker-build up down logs shell clean
+
+help:                  ## Muestra esta ayuda
+	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) \
+	  | sed 's/:.*##/—/' \
+	  | column -t -s '—'
+
+build:                 ## Construye la imagen Docker (target builder)
+	docker build --target builder \
+	             -t $(IMAGE_NAME) \
+	             .
+
+docker-build:          ## Alias de build
+	$(MAKE) build
+
+up:                    ## Arranca el servicio con docker-compose
+	docker compose -f $(COMPOSE_FILE) up --build api
+
+down:                  ## Detiene y quita contenedores
+	docker compose -f $(COMPOSE_FILE) down
+
+logs:                  ## Muestra los logs en tiempo real
+	docker logs -f $(CONTAINER_NAME)
+
+shell:                 ## Entra en shell dentro del contenedor de dev-envs
+	docker run -it --rm \
+	  --name temp-shell \
+	  -v $$(pwd)/app:/app \
+	  $(IMAGE_NAME):latest \
+	  bash
+
+clean:                 ## Elimina imágenes y contenedores generados
+	docker compose -f $(COMPOSE_FILE) down --rmi all
+	docker image prune -f

--- a/app/main.py
+++ b/app/main.py
@@ -1,3 +1,7 @@
+<<<<<<< Updated upstream
+=======
+# main.py
+>>>>>>> Stashed changes
 from fastapi import FastAPI
 
 app = FastAPI()

--- a/compose.yaml
+++ b/compose.yaml
@@ -1,3 +1,7 @@
+<<<<<<< Updated upstream
+=======
+# compose.yaml
+>>>>>>> Stashed changes
 services:
   api:
     build:


### PR DESCRIPTION
Description:

This PR introduces a Makefile to encapsulate and simplify common Docker and Docker Compose commands for the healthgen-conversation-fsm service. By defining reusable targets, we:

- Reduce command-line boilerplate for building, running, and cleaning containers/images
- Provide a self-documenting interface via make help
- Ensure consistency across development environments

Key Changes:

- Makefile
- help – list available targets and descriptions
- build – build the Docker image using the builder stage
- up – start the api service with docker compose up --build
- down – stop and remove containers (and networks)
- logs – tail logs from the running container
- shell – launch an interactive shell inside the dev image
- clean – tear down containers and prune images
- Updated documentation in README (if applicable) to reference the new Makefile